### PR TITLE
aws: fix issue with creating bucket in us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ The description of the AMI.
 
 The bucket to upload the image to during the upload process.
 
+### `base.aws.bucketRegionConstraint` / `variant.<name>.aws.bucketRegionConstraint`
+
+- Default: none (defaults to `us-east-1`)
+- Required: no
+- Template: no
+
+The region where the buckets exist or should be created.
 
 ### `base.aws.blobName` / `variant.<name>.aws.blobName`
 

--- a/config/config.go
+++ b/config/config.go
@@ -163,14 +163,15 @@ type fieldTemplateData struct {
 }
 
 type AWSConfig struct {
-	Region             string       `toml:"region,omitempty"`
-	ReplicationRegions []string     `toml:"replicationRegions,omitempty"`
-	AMIName            string       `toml:"amiName,omitempty" template:"true"`
-	AMIDescription     string       `toml:"amiDescription,omitempty" template:"true"`
-	Bucket             string       `toml:"bucket,omitempty" template:"true"`
-	BlobName           string       `toml:"blobName,omitempty" template:"true"`
-	SnapshotName       string       `toml:"snapshotName,omitempty" template:"true"`
-	Publish            Option[bool] `toml:"publish,omitempty"`
+	Region                   string       `toml:"region,omitempty"`
+	ReplicationRegions       []string     `toml:"replicationRegions,omitempty"`
+	AMIName                  string       `toml:"amiName,omitempty" template:"true"`
+	AMIDescription           string       `toml:"amiDescription,omitempty" template:"true"`
+	Bucket                   string       `toml:"bucket,omitempty" template:"true"`
+	BucketLocationConstraint string       `toml:"bucketLocationConstraint,omitempty" template:"false"`
+	BlobName                 string       `toml:"blobName,omitempty" template:"true"`
+	SnapshotName             string       `toml:"snapshotName,omitempty" template:"true"`
+	Publish                  Option[bool] `toml:"publish,omitempty"`
 }
 
 type AzureConfig struct {

--- a/config/validation.rego
+++ b/config/validation.rego
@@ -112,6 +112,42 @@ deny[msg] {
 
 deny[msg] {
     input.Provider == "aws"
+    input.AWS.BucketLocationConstraint in [
+		"af-south-1",
+		"ap-east-1",
+		"ap-northeast-1",
+		"ap-northeast-2",
+		"ap-northeast-3",
+		"ap-south-1",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"ap-southeast-3",
+		"ca-central-1",
+		"cn-north-1",
+		"cn-northwest-1",
+		"EU",
+		"eu-central-1",
+		"eu-north-1",
+		"eu-south-1",
+		"eu-west-1",
+		"eu-west-2",
+		"eu-west-3",
+		"me-south-1",
+		"sa-east-1",
+		"us-east-2",
+		"us-gov-east-1",
+		"us-gov-west-1",
+		"us-west-1",
+		"us-west-2",
+		"ap-south-2",
+		"eu-south-2",
+    ]
+
+    msg = sprintf("%q is not a valid bucket location constraint", [ input.AWS.BucketLocationConstraint ] )
+}
+
+deny[msg] {
+    input.Provider == "aws"
     not is_boolean(input.AWS.Publish)
 
     msg = "required field Publish uninitialized for provider aws"


### PR DESCRIPTION
Region us-east-1 isn't a valid parameter to a createBucket request. This caused the following error when uploading:

```
Error:
    uploading variants:
    uploading image:
    ensuring bucket exists:
    creating bucket xxx:
    operation error S3:
    CreateBucket, https response error StatusCode: 400, RequestID: xxx, HostID: xx,
    api error InvalidLocationConstraint:
    The specified location-constraint is not valid
```