### PR TITLE
logging: write to stderr

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -61,7 +61,7 @@ func newUploadCmd() *cobra.Command {
 }
 
 func runUpload(cmd *cobra.Command, args []string) error {
-	logger := log.New(cmd.OutOrStderr(), "", log.LstdFlags)
+	logger := log.New(cmd.ErrOrStderr(), "", log.LstdFlags)
 	imagePath := args[0]
 
 	flags, err := parseUploadFlags(cmd)


### PR DESCRIPTION
To make the output of uplos machine readable, log messages should only be written to stderr. This allows for easy parsing of the image references from stdout.