### PR TITLE
azure: expose regional replication as config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ The primary Azure region to upload the image to. Example: `northeurope`.
 This region is used for the resource group, disk and gallery.
 Subsequent images are replicated to all other regions specified in `replicationRegions`.
 
+### `base.azure.replicationRegions` / `variant.<name>.azure.replicationRegions`
+
+- Default: `[]`
+- Required: no
+
+Additional Azure regions that the image will be replicated in. Example: `["northeurope", "eastus2"]`.
+
 ### `base.azure.resourceGroup` / `variant.<name>.azure.resourceGroup`
 
 - Default: none

--- a/azure/uploader.go
+++ b/azure/uploader.go
@@ -479,7 +479,7 @@ func (u *Uploader) createImageVersion(ctx context.Context, imageID string) (stri
 			PublishingProfile: &armcomputev5.GalleryImageVersionPublishingProfile{
 				ReplicaCount:    toPtr[int32](1),
 				ReplicationMode: toPtr(armcomputev5.ReplicationModeFull),
-				TargetRegions:   targetRegions,
+				TargetRegions:   replication(u.config.Azure.Location, u.config.Azure.ReplicationRegions, 1),
 			},
 		},
 	}
@@ -609,29 +609,22 @@ func toPtr[T any](t T) *T {
 	return &t
 }
 
-var targetRegions = []*armcomputev5.TargetRegion{
-	{
-		Name:                 toPtr("germanywestcentral"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
-	{
-		Name:                 toPtr("northeurope"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
-	{
-		Name:                 toPtr("eastus"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
-	{
-		Name:                 toPtr("westeurope"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
-	{
-		Name:                 toPtr("westus"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
-	{
-		Name:                 toPtr("southeastasia"),
-		RegionalReplicaCount: toPtr[int32](1),
-	},
+func replication(location string, regions []string, count int32) []*armcomputev5.TargetRegion {
+	targetRegions := []*armcomputev5.TargetRegion{
+		{
+			Name:                 toPtr(location),
+			RegionalReplicaCount: toPtr[int32](count),
+		},
+	}
+	for _, region := range regions {
+		if region == location {
+			continue
+		}
+		targetRegions = append(targetRegions, &armcomputev5.TargetRegion{
+			Name:                 toPtr(region),
+			RegionalReplicaCount: toPtr[int32](count),
+		})
+	}
+
+	return targetRegions
 }

--- a/config/config.go
+++ b/config/config.go
@@ -175,18 +175,19 @@ type AWSConfig struct {
 }
 
 type AzureConfig struct {
-	SubscriptionID      string `toml:"subscriptionID,omitempty"`
-	Location            string `toml:"location,omitempty"`
-	ResourceGroup       string `toml:"resourceGroup,omitempty" template:"true"`
-	AttestationVariant  string `toml:"attestationVariant,omitempty" template:"true"`
-	SharedImageGallery  string `toml:"sharedImageGallery,omitempty" template:"true"`
-	SharingProfile      string `toml:"sharingProfile,omitempty" template:"true"`
-	SharingNamePrefix   string `toml:"sharingNamePrefix,omitempty" template:"true"`
-	ImageDefinitionName string `toml:"imageDefinitionName,omitempty" template:"true"`
-	Offer               string `toml:"offer,omitempty" template:"true"`
-	SKU                 string `toml:"sku,omitempty" template:"true"`
-	Publisher           string `toml:"publisher,omitempty" template:"true"`
-	DiskName            string `toml:"diskName,omitempty" template:"true"`
+	SubscriptionID      string   `toml:"subscriptionID,omitempty"`
+	Location            string   `toml:"location,omitempty"`
+	ReplicationRegions  []string `toml:"replicationRegions,omitempty"`
+	ResourceGroup       string   `toml:"resourceGroup,omitempty" template:"true"`
+	AttestationVariant  string   `toml:"attestationVariant,omitempty" template:"true"`
+	SharedImageGallery  string   `toml:"sharedImageGallery,omitempty" template:"true"`
+	SharingProfile      string   `toml:"sharingProfile,omitempty" template:"true"`
+	SharingNamePrefix   string   `toml:"sharingNamePrefix,omitempty" template:"true"`
+	ImageDefinitionName string   `toml:"imageDefinitionName,omitempty" template:"true"`
+	Offer               string   `toml:"offer,omitempty" template:"true"`
+	SKU                 string   `toml:"sku,omitempty" template:"true"`
+	Publisher           string   `toml:"publisher,omitempty" template:"true"`
+	DiskName            string   `toml:"diskName,omitempty" template:"true"`
 }
 
 type GCPConfig struct {

--- a/config/validation.rego
+++ b/config/validation.rego
@@ -409,6 +409,7 @@ required_fields := {
     "azure": {
         "subscriptionID": input.Azure.SubscriptionID,
         "location": input.Azure.Location,
+        "replicationRegions": input.Azure.ReplicationRegions,
         "resourceGroup": input.Azure.ResourceGroup,
         "attestationVariant": input.Azure.AttestationVariant,
         "sharedImageGallery": input.Azure.SharedImageGallery,


### PR DESCRIPTION
Constellation constantly needs new replication regions on Azure. Let's just make this configurable.