### PR TITLE
azure: added option for additionalSignatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Name of the temporary disk. Image is uploaded to this disk before being converte
 - Default: `[]`
 - Required: no
 
-Additional Secure Boot UEFI certificates can be added to the image to perform Trusted Launch with images that contain boot components which have been signed using a custom key. The certificates will be bound as UEFI db keys to an Image Version. The values have to specified as single-line base64-encoded DER certificates. Example: `["MIIC0DCCAbigAwIBAgIUI7..."]`.
+Additional Secure Boot UEFI certificates can be added to the image to perform Trusted Launch with images that contain boot components which have been signed using a custom key. The certificates will be bound as UEFI db keys to an Image Version. The values have to be specified as single-line base64-encoded DER certificates. Example: `["MIIC0DCCAbigAwIBAgIUI7..."]`.
 
 ### `base.gcp.project` / `variant.<name>.gcp.project`
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,13 @@ The organization that created the image. Example: `"Edgeless Systems"`.
 
 Name of the temporary disk. Image is uploaded to this disk before being converted to an image.
 
+### `base.azure.additionalSignatures` / `variant.<name>.azure.additionalSignatures`
+
+- Default: `[]`
+- Required: no
+
+Additional Secure Boot UEFI certificates can be added to the image to perform Trusted Launch with images that contain boot components which have been signed using a custom key. The certificates will be bound as UEFI db keys to an Image Version. The values have to specified as single-line base64-encoded DER certificates. Example: `["MIIC0DCCAbigAwIBAgIUI7..."]`.
+
 ### `base.gcp.project` / `variant.<name>.gcp.project`
 
 - Default: none

--- a/azure/uploader.go
+++ b/azure/uploader.go
@@ -483,6 +483,29 @@ func (u *Uploader) createImageVersion(ctx context.Context, imageID string) (stri
 			},
 		},
 	}
+
+	if u.config.Azure.AdditionalSignatures != nil {
+		value := make([]*string, 0)
+		for _, sig := range u.config.Azure.AdditionalSignatures {
+			value = append(value, toPtr(sig))
+		}
+		imageVersion.Properties.SecurityProfile = &armcomputev5.ImageVersionSecurityProfile{
+			UefiSettings: &armcomputev5.GalleryImageVersionUefiSettings{
+				SignatureTemplateNames: []*armcomputev5.UefiSignatureTemplateName{
+					toPtr(armcomputev5.UefiSignatureTemplateNameMicrosoftUefiCertificateAuthorityTemplate),
+				},
+				AdditionalSignatures: &armcomputev5.UefiKeySignatures{
+					Db: []*armcomputev5.UefiKey{
+						&armcomputev5.UefiKey{
+							Type:  toPtr(armcomputev5.UefiKeyTypeX509),
+							Value: value,
+						},
+					},
+				},
+			},
+		}
+	}
+
 	createPoller, err := u.imageVersions.BeginCreateOrUpdate(ctx, rg, sigName, defName, verName, imageVersion,
 		&armcomputev5.GalleryImageVersionsClientBeginCreateOrUpdateOptions{},
 	)

--- a/azure/uploader.go
+++ b/azure/uploader.go
@@ -485,7 +485,7 @@ func (u *Uploader) createImageVersion(ctx context.Context, imageID string) (stri
 	}
 
 	if u.config.Azure.AdditionalSignatures != nil {
-		value := make([]*string, 0)
+		var value []*string
 		for _, sig := range u.config.Azure.AdditionalSignatures {
 			value = append(value, toPtr(sig))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -184,19 +184,20 @@ type AWSConfig struct {
 }
 
 type AzureConfig struct {
-	SubscriptionID      string   `toml:"subscriptionID,omitempty"`
-	Location            string   `toml:"location,omitempty"`
-	ReplicationRegions  []string `toml:"replicationRegions,omitempty"`
-	ResourceGroup       string   `toml:"resourceGroup,omitempty" template:"true"`
-	AttestationVariant  string   `toml:"attestationVariant,omitempty" template:"true"`
-	SharedImageGallery  string   `toml:"sharedImageGallery,omitempty" template:"true"`
-	SharingProfile      string   `toml:"sharingProfile,omitempty" template:"true"`
-	SharingNamePrefix   string   `toml:"sharingNamePrefix,omitempty" template:"true"`
-	ImageDefinitionName string   `toml:"imageDefinitionName,omitempty" template:"true"`
-	Offer               string   `toml:"offer,omitempty" template:"true"`
-	SKU                 string   `toml:"sku,omitempty" template:"true"`
-	Publisher           string   `toml:"publisher,omitempty" template:"true"`
-	DiskName            string   `toml:"diskName,omitempty" template:"true"`
+	SubscriptionID       string   `toml:"subscriptionID,omitempty"`
+	Location             string   `toml:"location,omitempty"`
+	ReplicationRegions   []string `toml:"replicationRegions,omitempty"`
+	ResourceGroup        string   `toml:"resourceGroup,omitempty" template:"true"`
+	AttestationVariant   string   `toml:"attestationVariant,omitempty" template:"true"`
+	SharedImageGallery   string   `toml:"sharedImageGallery,omitempty" template:"true"`
+	SharingProfile       string   `toml:"sharingProfile,omitempty" template:"true"`
+	SharingNamePrefix    string   `toml:"sharingNamePrefix,omitempty" template:"true"`
+	ImageDefinitionName  string   `toml:"imageDefinitionName,omitempty" template:"true"`
+	Offer                string   `toml:"offer,omitempty" template:"true"`
+	SKU                  string   `toml:"sku,omitempty" template:"true"`
+	Publisher            string   `toml:"publisher,omitempty" template:"true"`
+	DiskName             string   `toml:"diskName,omitempty" template:"true"`
+	AdditionalSignatures []string `toml:"additionalSignatures,omitempty"`
 }
 
 type GCPConfig struct {


### PR DESCRIPTION
A feature has recently been make public allowing to seed custom certificates to Image Versions in azure, which allows TrustedLaunch/SecureBoot for e.g. custom kernels that have been signed with custom keys.

~Note: The additional keys will be appear in a machine's UEFI db if it has been launched w/ SecureBoot enabled.~

Note: The provisioning of UEFI certs does not yet work if image versions are referenced via their CommunityGallery Id, support for this is pending.

```bash
$ mokutil --sb-state
SecureBootEnabled

$ keyctl list %.platform
...
966898153: ---lswrv     0     0 asymmetric: mkosi of magnuskulke: 22d8f39cb9d11b0f179ca7bbb247857aca63bade
...

$ dmesg | grep mkosi
[    2.933854] integrity: Loaded X.509 cert 'mkosi of magnuskulke: 22d8f39cb9d11b0f179ca7bbb247857aca63bade'
```