### PR TITLE
Update README.md for default value of `base.azure.sharingProfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Will be created if it does not exist. The name must be unique within the subscri
 
 ### `base.azure.sharingProfile` / `variant.<name>.azure.sharingProfile`
 
-- Default: `"community"`
+- Default: `"private"`
 - Required: no
 - Template: yes
 


### PR DESCRIPTION
As per https://github.com/edgelesssys/uplosi/pull/99 the default value is `private`. So reflecting this in the readme