### PR TITLE
measurements: add flag for generating event log

### DIFF
--- a/measurements.go
+++ b/measurements.go
@@ -27,6 +27,7 @@ func newMeasurementsCmd() *cobra.Command {
 		RunE:  runMeasurements,
 	}
 	cmd.Flags().StringP("output-file", "o", "", "Output file for the precalculated measurements")
+	cmd.Flags().StringP("eventlog-output", "e", "", "Output file for the event log. If not set, the event log is not written")
 	cmd.Flags().StringP("uki-path", "u", measuredboot.UkiPath, "Path to the UKI file in the image")
 
 	return cmd
@@ -53,12 +54,20 @@ func runMeasurements(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Wrote precalculated measurements to %s\n", flags.outputFile)
 	}
 
+	if flags.eventlogOutput != "" {
+		if err := afero.WriteFile(fs, flags.eventlogOutput, []byte(simulator.String()), 0644); err != nil {
+			return fmt.Errorf("creating event log output file: %w", err)
+		}
+		cmd.Printf("Wrote event log to %s\n", flags.eventlogOutput)
+	}
+
 	return nil
 }
 
 type measurementsFlags struct {
-	outputFile string
-	ukiPath    string
+	outputFile     string
+	eventlogOutput string
+	ukiPath        string
 }
 
 func parseMeasurementsFlags(cmd *cobra.Command) (*measurementsFlags, error) {
@@ -70,9 +79,14 @@ func parseMeasurementsFlags(cmd *cobra.Command) (*measurementsFlags, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting uki-path flag: %w", err)
 	}
+	eventlogOutput, err := cmd.Flags().GetString("eventlog-output")
+	if err != nil {
+		return nil, fmt.Errorf("getting eventlog-output flag: %w", err)
+	}
 	return &measurementsFlags{
-		outputFile: outputFile,
-		ukiPath:    ukiPath,
+		outputFile:     outputFile,
+		ukiPath:        ukiPath,
+		eventlogOutput: eventlogOutput,
 	}, nil
 }
 


### PR DESCRIPTION
The event log generation feature was previously not exposed in the CLI. This PR does it by adding a `eventlog-output` flag.