### PR TITLE
aws/config: fix inverted location constraint validation

### DIFF
--- a/config/validation.rego
+++ b/config/validation.rego
@@ -110,9 +110,10 @@ deny[msg] {
     msg = sprintf("bucket name %q must not end with the suffix --ol-s3", [input.AWS.Bucket])
 }
 
+# https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketConfiguration.html
 deny[msg] {
     input.Provider == "aws"
-    input.AWS.BucketLocationConstraint in [
+    not input.AWS.BucketLocationConstraint in [
 		"af-south-1",
 		"ap-east-1",
 		"ap-northeast-1",
@@ -122,18 +123,24 @@ deny[msg] {
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"ap-southeast-3",
+		"ap-southeast-4",
+		"ap-southeast-5",
 		"ca-central-1",
 		"cn-north-1",
 		"cn-northwest-1",
 		"EU",
 		"eu-central-1",
+		"eu-central-2",
 		"eu-north-1",
 		"eu-south-1",
 		"eu-west-1",
 		"eu-west-2",
 		"eu-west-3",
+		"il-central-1",
+		"me-central-1",
 		"me-south-1",
 		"sa-east-1",
+		"us-east-1",
 		"us-east-2",
 		"us-gov-east-1",
 		"us-gov-west-1",


### PR DESCRIPTION
This PR first tackled a bug:
- The Rego file would deny all locations except the actually allowed ones for an AWS S3 bucket, according to their [API docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketConfiguration.html).

By fixing it, a derivative bug was discovered:
- The allowed location list does not include the default value, `us-east-1`, which would cause the default configuration to be denied.

The list of allowed locations in the API docs mentioned before does not include the `us-east-1`, which is also AWS's default. This appears to be a mistake/misguidance in the docs themselves. Therefore, this PR now includes the `us-east-1` in the allowed location list.

Additionally, new locations are allowed according to the documentation, so this PR also adds them.